### PR TITLE
Including an example of a domain event raised through MediatR, keepin…

### DIFF
--- a/Server/robot.Application/Features/Robo/Handlers/HeadRotateHandler.cs
+++ b/Server/robot.Application/Features/Robo/Handlers/HeadRotateHandler.cs
@@ -1,5 +1,6 @@
 ﻿using MediatR;
 using robot.Application.Features.Robo.Commands;
+using robot.Application.Notification;
 using robot.Domain.Results;
 using System;
 using System.Threading;
@@ -12,10 +13,12 @@ namespace robot.Application.Features.Robo.Handlers
     public class HeadRotateHandler : IRequestHandler<HeadRotateCommand, Result<Exception, int>>
     {
         private readonly IRobotRepository _repository;
+        private readonly IMediator _mediator;
 
-        public HeadRotateHandler(IRobotRepository repository)
+        public HeadRotateHandler(IRobotRepository repository, IMediator mediator)
         {
             _repository = repository;
+            _mediator = mediator;
         }
 
         public Task<Result<Exception, int>> Handle(HeadRotateCommand command, CancellationToken cancellationToken)
@@ -42,6 +45,9 @@ namespace robot.Application.Features.Robo.Handlers
                 default:
                     return new BussinessException(ErrorCodes.BadRequest, "Comando inválido.");
             }
+
+            // Publish Domain Events
+            _mediator.PublishDomainEvents(robot.RaisedEvents());
 
             if (rotateCallback.IsSuccess)
                 return PersistRobotState(robot, rotateCallback.Success);

--- a/Server/robot.Application/Features/Robo/Handlers/HeadRotateNotificationHandler.cs
+++ b/Server/robot.Application/Features/Robo/Handlers/HeadRotateNotificationHandler.cs
@@ -1,0 +1,31 @@
+﻿using MediatR;
+using robot.Application.Notification;
+using robot.Domain.Features.Robo;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace robot.Application.Features.Robo.Handlers
+{
+    /// <summary>
+    /// Handler que implementa o disparo do evento 
+    /// </summary>
+    public class HeadRotateNotificationHandler : INotificationHandler<DomainEventAdapter<DeniedHeadRotateEvent>>
+    {
+
+        public HeadRotateNotificationHandler()
+        {
+
+        }
+
+        public Task Handle(DomainEventAdapter<DeniedHeadRotateEvent> notification, CancellationToken cancellationToken)
+        {
+            //TODO: Inventar alguma coisa funcional
+            return Task.Run(() =>
+                    Debug.WriteLine($"Evento de Rotação Limitada para a {notification.DomainEvent._direction}"));
+        }
+    }
+}

--- a/Server/robot.Application/Notification/DomainEventAdapter.cs
+++ b/Server/robot.Application/Notification/DomainEventAdapter.cs
@@ -1,0 +1,24 @@
+﻿using MediatR;
+using robot.Domain;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace robot.Application.Notification
+{ 
+    /// <summary>
+    /// Classe utilizada para adaptar o domain event para ser processado
+    /// pelo Mediator, seguindo a padrão de usar INotification
+    /// </summary>
+    /// <typeparam name="TDomainEvent"></typeparam>
+    public class DomainEventAdapter<TDomainEvent> : INotification where TDomainEvent : IEvent
+    {
+        public TDomainEvent DomainEvent { get; }
+
+        public DomainEventAdapter(TDomainEvent domainEvent)
+        {
+            DomainEvent = domainEvent;
+        }
+    }
+
+}

--- a/Server/robot.Application/Notification/DomainEventDispatcher.cs
+++ b/Server/robot.Application/Notification/DomainEventDispatcher.cs
@@ -1,0 +1,32 @@
+﻿using MediatR;
+using robot.Domain;
+using System.Collections.Generic;
+
+namespace robot.Application.Notification
+{
+    /// <summary>
+    /// Classe utilizada para estender o comportamento do Mediator
+    /// publicando um evento de dominio genérico atráves de um Adapter
+    /// </summary>
+    public static class DomainEventDispatcher
+    {    
+        public static void PublishDomainEvents(this IMediator _mediator, IEnumerable<IEvent> events)
+        {
+            if (events == null)
+                return;
+
+            foreach (var @event in events)
+            {
+                var domainEventNotification = CreateDomainEventNotification((dynamic)@event);
+
+                _mediator.Publish(domainEventNotification);
+            }
+        }
+
+        private static DomainEventAdapter<TDomainEvent> CreateDomainEventNotification<TDomainEvent>(TDomainEvent domainEvent)
+            where TDomainEvent : IEvent
+        {
+            return new DomainEventAdapter<TDomainEvent>(domainEvent);
+        }
+    }
+}

--- a/Server/robot.Domain.Test/Entities/RobotRotateHeadUnitTest.cs
+++ b/Server/robot.Domain.Test/Entities/RobotRotateHeadUnitTest.cs
@@ -63,6 +63,7 @@ namespace robot.Domain.Test
             result.IsFailure.ShouldBeTrue();
             result.Failure.ShouldBeOfType<DeniedHeadRotateException>();
             robot.HeadDirection.ShouldBe(0);
+            robot.RaisedEvents().ShouldHaveSingleItem();
         }
 
         [Test]
@@ -81,6 +82,7 @@ namespace robot.Domain.Test
             result.IsFailure.ShouldBeTrue();
             result.Failure.ShouldBeOfType<DeniedHeadRotateException>();
             robot.HeadDirection.ShouldBe(0);
+            robot.RaisedEvents().ShouldHaveSingleItem();
         }
 
         [Test]

--- a/Server/robot.Domain/AggregateRoot.cs
+++ b/Server/robot.Domain/AggregateRoot.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace robot.Domain
+{
+    /// <summary>
+    /// Classe abstrata que define o comportamento
+    /// de disparo de eventos do dominio.
+    /// A ideia é que os eventos de domínio não seja disparados imediatamente:
+    /// fonte: https://lostechies.com/jimmybogard/2014/05/13/a-better-domain-events-pattern/
+    /// </summary>
+    public abstract class AggregateRoot
+    {
+        private List<IEvent> events;
+
+        public void Raise(IEvent @event)
+        {
+            if (events == null)
+            {
+                events = new List<IEvent>();
+            }
+
+            events.Add(@event);
+        }
+
+        public virtual IEnumerable<IEvent> RaisedEvents() => events;
+    }
+}

--- a/Server/robot.Domain/Features/Robo/DeniedHeadRotateEvent.cs
+++ b/Server/robot.Domain/Features/Robo/DeniedHeadRotateEvent.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace robot.Domain.Features.Robo
+{
+    /// <summary>
+    /// Classe que representa um evento de dominio
+    /// Quando o robo tentou rotacionar a cabeça
+    /// </summary>
+    public class DeniedHeadRotateEvent : IEvent
+    {
+        public DeniedHeadRotateEvent(Head head, string direction)
+        {
+            _head = head;
+            _direction = direction;
+        }
+
+        public Head _head { get; private set; }
+        public string _direction { get; private set; }
+    }
+}

--- a/Server/robot.Domain/Features/Robo/RobotAgreggate.cs
+++ b/Server/robot.Domain/Features/Robo/RobotAgreggate.cs
@@ -4,7 +4,7 @@ using robot.Domain.Exceptions;
 
 namespace robot.Domain.Features.Robo
 {
-    public abstract class RobotAgreggate
+    public abstract class RobotAgreggate : AggregateRoot
     {
         protected RobotAgreggate() { }
 
@@ -45,7 +45,10 @@ namespace robot.Domain.Features.Robo
         public Result<Exception, int> RotateHeadToTheLeft()
         {
             if (!CanHeadRotate())
+            {
+                Raise(new DeniedHeadRotateEvent(Head, "Left"));
                 return new DeniedHeadRotateException();
+            }
 
             return Head.RotateToTheLeft();
         }
@@ -56,7 +59,10 @@ namespace robot.Domain.Features.Robo
         public Result<Exception, int> RotateHeadToTheRight()
         {
             if (!CanHeadRotate())
+            {
+                Raise(new DeniedHeadRotateEvent(Head, "Right"));
                 return new DeniedHeadRotateException();
+            }
 
             return Head.RotateToTheRight();
         }

--- a/Server/robot.Domain/IEvent.cs
+++ b/Server/robot.Domain/IEvent.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace robot.Domain
+{
+    /// <summary>
+    /// Interface utilizada para identificar uma classe como 
+    /// classe usada para eventos
+    /// </summary>
+    public interface IEvent
+    {
+    }
+}


### PR DESCRIPTION
Including an example of a domain event raised through MediatR, keeping the Domain Layer isolated from the MediatR library.

![reliable-events](https://user-images.githubusercontent.com/5650042/50997643-3f760200-150c-11e9-8cd7-f03caf6eb2ae.png)

